### PR TITLE
Fix miro_board update request

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/Miro-Ecosystem/terraform-provider-miro
 go 1.14
 
 require (
-	github.com/Miro-Ecosystem/go-miro v0.0.11
+	github.com/Miro-Ecosystem/go-miro v0.0.12
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.0.3
 )

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Miro-Ecosystem/go-miro v0.0.11 h1:v9jfjlKY/lGs+L1GTGgXyMJ9erbXIDr46dqGk1lfu+M=
 github.com/Miro-Ecosystem/go-miro v0.0.11/go.mod h1:dv/664pZSrK3cV5TZhHLSdO+Gg2o6BFMHnllS3sDR8c=
+github.com/Miro-Ecosystem/go-miro v0.0.12 h1:naiSvZTOUWzgxUCG5fpbTeYrxOTQk0l//lI079api3k=
+github.com/Miro-Ecosystem/go-miro v0.0.12/go.mod h1:dv/664pZSrK3cV5TZhHLSdO+Gg2o6BFMHnllS3sDR8c=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/miro/resource_board.go
+++ b/miro/resource_board.go
@@ -73,6 +73,7 @@ func resourceBoardCreate(ctx context.Context, data *schema.ResourceData, meta in
 
 func resourceBoardUpdate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*miro.Client)
+	id := data.Id()
 	name := data.Get("name").(string)
 	description := data.Get("description").(string)
 
@@ -81,7 +82,7 @@ func resourceBoardUpdate(ctx context.Context, data *schema.ResourceData, meta in
 		Description: description,
 	}
 
-	_, err := c.Boards.Update(ctx, req)
+	_, err := c.Boards.Update(ctx, id, req)
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
## What
As title.

## Why
Because the new release for `go-miro@0.0.12` is released. 